### PR TITLE
Corrigido problema de importação do arquivo dijkstra.rb no linux.

### DIFF
--- a/main.rb
+++ b/main.rb
@@ -1,4 +1,4 @@
-require "dijkstra.rb"
+require_relative "dijkstra"
 
 ## Carregando arquivo para o vetor
 arquivo = ARGV.first


### PR DESCRIPTION
Erro que é apresentado:

```

`require': cannot load such file -- dijkstra.rb (LoadError)

```
